### PR TITLE
Add GitHub Actions CI for Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,97 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    
+    - name: Build
+      run: cargo build --verbose
+    
+    - name: Build release
+      run: cargo build --release --verbose
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    
+    - name: Check formatting
+      run: cargo fmt -- --check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    
+    - name: Run tests
+      run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Logger
 
+![Rust CI](https://github.com/suzuki-toshihir0/claude-logger/workflows/Rust%20CI/badge.svg)
+
 ***<span style="font-size: 140%">Work Out Loud with your Claude Code!</span>***
 
 Real-time monitoring tool for Claude Code conversations. Watches JSONL log files and streams formatted messages to stdout with optional webhook integration.

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -76,12 +76,12 @@ impl LogFormatter {
 
         // Message content
         let formatted_content = self.format_message_content(message)?;
-        
+
         // Skip empty messages (filtered tool messages in none mode)
         if formatted_content.trim().is_empty() {
             return Ok(String::new());
         }
-        
+
         if self.compact_mode {
             // Compact mode: show only first 100 characters
             let content = if formatted_content.len() > 100 {
@@ -111,9 +111,10 @@ impl LogFormatter {
             match self.tool_display_mode {
                 crate::ToolDisplayMode::None => {
                     // Filter out tool messages, but keep text content
-                    if message.content.trim().is_empty() || 
-                       message.content.starts_with("[Tool") ||
-                       message.content.starts_with("[Thinking") {
+                    if message.content.trim().is_empty()
+                        || message.content.starts_with("[Tool")
+                        || message.content.starts_with("[Thinking")
+                    {
                         return Ok(String::new());
                     }
                 }
@@ -142,16 +143,16 @@ impl LogFormatter {
                                     .get("name")
                                     .and_then(|n| n.as_str())
                                     .unwrap_or("Unknown");
-                                
+
                                 let simple = format!("🔧 {tool_name}");
-                                
+
                                 let detailed = if let Some(input) = obj.get("input") {
                                     let input_str = self.format_tool_input(input);
                                     format!("🔧 {tool_name}: {input_str}")
                                 } else {
                                     simple.clone()
                                 };
-                                
+
                                 return Some(ToolContent {
                                     simple_format: simple,
                                     detailed_format: detailed,
@@ -159,14 +160,14 @@ impl LogFormatter {
                             }
                             "tool_result" => {
                                 let simple = "✅ Result".to_string();
-                                
+
                                 let detailed = if let Some(content) = obj.get("content") {
                                     let content_str = self.format_tool_result(content);
                                     format!("✅ {content_str}")
                                 } else {
                                     simple.clone()
                                 };
-                                
+
                                 return Some(ToolContent {
                                     simple_format: simple,
                                     detailed_format: detailed,
@@ -204,7 +205,7 @@ impl LogFormatter {
                 let truncated = s.chars().take(50).collect::<String>();
                 truncated + if s.len() > 50 { "..." } else { "" }
             }
-            _ => "(...)".to_string()
+            _ => "(...)".to_string(),
         }
     }
 
@@ -216,7 +217,7 @@ impl LogFormatter {
                 let truncated = first_line.chars().take(50).collect::<String>();
                 truncated + if first_line.len() > 50 { "..." } else { "" }
             }
-            _ => "Result".to_string()
+            _ => "Result".to_string(),
         }
     }
 
@@ -279,6 +280,7 @@ mod tests {
             timestamp: Utc::now(),
             session_id: "test-session-12345".to_string(),
             uuid: "test-uuid".to_string(),
+            raw_content: None,
         }
     }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -11,7 +11,7 @@ use tokio::time::{Duration, sleep};
 use crate::formatter::LogFormatter;
 use crate::parser::LogParser;
 use crate::webhook::WebhookSender;
-use crate::{WebhookFormat};
+use crate::WebhookFormat;
 use url::Url;
 
 pub struct LogWatcher {
@@ -51,7 +51,7 @@ impl LogWatcher {
                     println!("Webhook configured successfully");
                 }
                 Err(e) => {
-                    eprintln!("Failed to configure webhook: {}", e);
+                    eprintln!("Failed to configure webhook: {e}");
                 }
             }
         }
@@ -231,7 +231,7 @@ impl LogWatcher {
                 // Send to webhook if configured
                 if let Some(ref webhook) = self.webhook_sender {
                     if let Err(e) = webhook.send_message(&message, &formatted).await {
-                        eprintln!("Failed to send webhook: {}", e);
+                        eprintln!("Failed to send webhook: {e}");
                     }
                 }
             }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -8,10 +8,10 @@ use std::time::SystemTime;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio::time::{Duration, sleep};
 
+use crate::WebhookFormat;
 use crate::formatter::LogFormatter;
 use crate::parser::LogParser;
 use crate::webhook::WebhookSender;
-use crate::WebhookFormat;
 use url::Url;
 
 pub struct LogWatcher {

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -30,7 +30,7 @@ impl WebhookSender {
     /// Send message to webhook
     pub async fn send_message(&self, message: &LogMessage, formatted_content: &str) -> Result<()> {
         let payload = self.format_message(message, formatted_content)?;
-        
+
         let response = self
             .client
             .post(self.url.clone())
@@ -85,14 +85,13 @@ impl WebhookSender {
             ]
         }))
     }
-
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
     use crate::parser::MessageRole;
+    use chrono::Utc;
 
     fn create_test_message() -> LogMessage {
         LogMessage {
@@ -110,9 +109,11 @@ mod tests {
         let url = Url::parse("https://example.com/webhook").unwrap();
         let sender = WebhookSender::new(url, WebhookFormat::Generic).unwrap();
         let message = create_test_message();
-        
-        let result = sender.format_generic(&message, "Formatted content").unwrap();
-        
+
+        let result = sender
+            .format_generic(&message, "Formatted content")
+            .unwrap();
+
         assert!(result.get("content").is_some());
         assert!(result.get("role").is_some());
         assert!(result.get("timestamp").is_some());
@@ -123,11 +124,10 @@ mod tests {
         let url = Url::parse("https://example.com/webhook").unwrap();
         let sender = WebhookSender::new(url, WebhookFormat::Slack).unwrap();
         let message = create_test_message();
-        
+
         let result = sender.format_slack(&message, "Formatted content").unwrap();
-        
+
         assert!(result.get("text").is_some());
         assert!(result.get("blocks").is_some());
     }
-
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::time::Duration;
 use url::Url;
 
-use crate::parser::LogMessage;
 use crate::WebhookFormat;
+use crate::parser::LogMessage;
 
 pub struct WebhookSender {
     client: Client,


### PR DESCRIPTION
## Summary
- Add comprehensive CI workflow with build, clippy, fmt, and test jobs
- Configure dependency caching for faster builds
- Add CI status badge to README

## Details
This PR adds a GitHub Actions workflow that runs on every push to main and on pull requests. The CI includes:

- **Build**: Compiles the project in both debug and release modes
- **Clippy**: Runs clippy with strict warnings (`-D warnings`)
- **Format**: Checks code formatting with rustfmt
- **Test**: Runs all tests with verbose output

Each job runs in parallel for faster feedback, and dependencies are cached to speed up subsequent runs.

## Test plan
- [ ] CI runs successfully on this PR
- [ ] All jobs pass (build, clippy, fmt, test)
- [ ] Badge displays correctly in README

🤖 Generated with [Claude Code](https://claude.ai/code)