### PR TITLE
Prepare for cargo publish: add package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "claude-logger"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
+authors = ["Toshihiro Suzuki"]
+description = "Real-time monitoring tool for Claude Code conversations with webhook support"
+repository = "https://github.com/suzuki-toshihir0/claude-logger"
+license = "MIT"
+readme = "README.md"
+keywords = ["claude", "monitoring", "logger", "webhook", "cli"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 notify = "6.1"

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,17 +1,17 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use notify::{Event, EventKind, RecursiveMode, Watcher, event::CreateKind};
+use notify::{event::CreateKind, Event, EventKind, RecursiveMode, Watcher};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::SystemTime;
 use tokio::sync::mpsc as tokio_mpsc;
-use tokio::time::{Duration, sleep};
+use tokio::time::{sleep, Duration};
 
-use crate::WebhookFormat;
 use crate::formatter::LogFormatter;
 use crate::parser::LogParser;
 use crate::webhook::WebhookSender;
+use crate::WebhookFormat;
 use url::Url;
 
 pub struct LogWatcher {

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
 use reqwest::Client;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::time::Duration;
 use url::Url;
 
-use crate::WebhookFormat;
 use crate::parser::LogMessage;
+use crate::WebhookFormat;
 
 pub struct WebhookSender {
     client: Client,


### PR DESCRIPTION
## Summary
- Add necessary metadata for cargo publish
- Fix edition from 2024 to 2021 for compatibility
- Add author, description, repository, license information
- Add keywords and categories for better discoverability

## Changes
- Update Cargo.toml with package metadata
- Ensure all required fields for crates.io publication

## Test plan
- [x] Package compiles with new metadata
- [ ] Ready for `cargo publish`

🤖 Generated with [Claude Code](https://claude.ai/code)