### PR TITLE
Update installation instructions and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ cargo fmt
 
 # Check compilation without building
 cargo check
+
+# Publish to crates.io
+cargo publish
 ```
 
 ## High-Level Architecture
@@ -105,7 +108,10 @@ The formatter handles several message types:
 # Run unit tests
 cargo test
 
-# Test webhook formatting
+# Test specific module
+cargo test webhook
+
+# Test with pattern matching
 cargo test format_slack
 
 # Manual testing with real Claude session
@@ -118,6 +124,16 @@ cargo test format_slack
 1. **Duplicate message output**: Resolved by timestamp filtering in `process_jsonl_file`
 2. **Webhook spam on startup**: Use default `--include-existing=false`
 3. **Tool output noise**: Adjust with `--tool-display none`
+
+## Installation & Distribution
+
+```bash
+# Install from crates.io
+cargo install claude-logger
+
+# Install from local source
+cargo install --path .
+```
 
 ## Future Extension Points
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,15 @@ Real-time monitoring tool for Claude Code conversations. Watches JSONL log files
 ## Installation
 
 ```bash
+cargo install claude-logger
+```
+
+Or build from source:
+```bash
 git clone git@github.com:suzuki-toshihir0/claude-logger.git
 cd claude-logger
 cargo build --release
 ```
-
-The binary will be available at `./target/release/claude-logger`
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Update README.md to use `cargo install claude-logger` as primary installation method
- Enhance CLAUDE.md with cargo publish command and installation section
- Add module-specific testing examples

## Changes
- README.md: Add cargo install option, keep build from source as alternative
- CLAUDE.md: Add cargo publish to development commands
- CLAUDE.md: Add Installation & Distribution section
- CLAUDE.md: Enhance testing section with module-specific examples

🤖 Generated with [Claude Code](https://claude.ai/code)