### PR TITLE
Add project and session identification to Slack webhook usernames

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -280,6 +280,7 @@ mod tests {
             timestamp: Utc::now(),
             session_id: "test-session-12345".to_string(),
             uuid: "test-uuid".to_string(),
+            project_name: "test-project".to_string(),
             raw_content: None,
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -189,12 +189,17 @@ impl LogParser {
             .ok()
             .map(BufReader::new)
             .and_then(|reader| {
-                reader.lines()
+                reader
+                    .lines()
                     .take(10)
                     .filter_map(|line| line.ok())
                     .filter_map(|line| serde_json::from_str::<CwdEntry>(&line).ok())
                     .filter_map(|entry| entry.cwd)
-                    .filter_map(|cwd| Path::new(&cwd).file_name().and_then(|name| name.to_str().map(String::from)))
+                    .filter_map(|cwd| {
+                        Path::new(&cwd)
+                            .file_name()
+                            .and_then(|name| name.to_str().map(String::from))
+                    })
                     .next()
             });
 

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -69,11 +69,14 @@ impl WebhookSender {
     }
 
     /// Slack webhook format
-    fn format_slack(&self, _message: &LogMessage, formatted_content: &str) -> Result<Value> {
+    fn format_slack(&self, message: &LogMessage, formatted_content: &str) -> Result<Value> {
+        let session_short = &message.session_id[..8.min(message.session_id.len())];
+        let username = format!("Claude Code / {} | {}", message.project_name, session_short);
         let text = formatted_content.to_string();
 
         Ok(json!({
             "text": text,
+            "username": username,
             "blocks": [
                 {
                     "type": "section",
@@ -100,6 +103,7 @@ mod tests {
             timestamp: Utc::now(),
             session_id: "test-session-12345".to_string(),
             uuid: "test-uuid".to_string(),
+            project_name: "test-project".to_string(),
             raw_content: None,
         }
     }


### PR DESCRIPTION
## Summary
- Add project and session identification to Slack webhook usernames for better Working Out Loud experience
- Extract project name from JSONL file's cwd field with fallback to directory name
- Format username as "Claude Code / <project-name>  < /dev/null |  <session-id>" to distinguish multiple sessions

## Changes
- Add `project_name` field to `LogMessage` struct
- Implement project name extraction from cwd field in JSONL files
- Update Slack webhook format to include project and session info in username
- Maintain backward compatibility with fallback to directory name

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] Manual testing with multiple Claude Code sessions shows distinct usernames

🤖 Generated with [Claude Code](https://claude.ai/code)