### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "claude-logger"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "claude-logger"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-logger"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Toshihiro Suzuki"]
 description = "Real-time monitoring tool for Claude Code conversations with webhook support"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 to 0.1.2
- Include webhook filtering improvements from PR #7

## Changes
- Update version in Cargo.toml
- Update Cargo.lock

🤖 Generated with [Claude Code](https://claude.ai/code)