### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "claude-logger"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-logger"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Toshihiro Suzuki"]
 description = "Real-time monitoring tool for Claude Code conversations with webhook support"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.2 to 0.1.3
- Update Cargo.toml and Cargo.lock

## Changes in v0.1.3
- Fix `watch --latest` to correctly identify the most recently active project
- Use JSONL file modification times instead of directory modification times for more accurate detection

🤖 Generated with [Claude Code](https://claude.ai/code)