### PR TITLE
Improve TodoWrite display with detailed task lists

### DIFF
--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use url::Url;
 
 use crate::parser::LogMessage;
+use crate::formatter::LogFormatter;
 use crate::WebhookFormat;
 
 #[derive(Debug)]
@@ -17,6 +18,7 @@ pub struct WebhookSender {
     client: Client,
     url: Url,
     format: WebhookFormat,
+    formatter: LogFormatter,
 }
 
 impl WebhookSender {
@@ -26,10 +28,14 @@ impl WebhookSender {
             .build()
             .context("Failed to create HTTP client")?;
 
+        let formatter = LogFormatter::new()
+            .with_tool_display_mode(crate::ToolDisplayMode::Detailed);
+
         Ok(Self {
             client,
             url,
             format,
+            formatter,
         })
     }
 
@@ -117,7 +123,69 @@ impl WebhookSender {
     fn format_message(&self, message: &LogMessage, formatted_content: &str) -> Result<Value> {
         match self.format {
             WebhookFormat::Generic => self.format_generic(message, formatted_content),
-            WebhookFormat::Slack => self.format_slack(message, formatted_content),
+            WebhookFormat::Slack => {
+                let slack_content = self.format_content_for_slack(message);
+                self.format_slack(message, &slack_content)
+            }
+        }
+    }
+
+    /// Format message content specifically for Slack
+    fn format_content_for_slack(&self, message: &LogMessage) -> String {
+        let Some(ref raw_content) = message.raw_content else {
+            return message.content.clone();
+        };
+
+        let Value::Array(arr) = raw_content else {
+            return message.content.clone();
+        };
+
+        for item in arr {
+            let Some(obj) = item.as_object() else { continue };
+            let Some(content_type) = obj.get("type").and_then(|t| t.as_str()) else { continue };
+
+            if content_type == "tool_use" {
+                let Some(tool_name) = obj.get("name").and_then(|n| n.as_str()) else { continue };
+                
+                if tool_name == "TodoWrite" {
+                    let Some(input) = obj.get("input") else { continue };
+                    let Some(todos) = input.get("todos") else { continue };
+                    
+                    let slack_todos = self.formatter.format_todos_for_slack(todos);
+                    return format!("📝 TodoWrite: {}", slack_todos);
+                }
+                
+                // Handle other tools with generic format
+                let tool_icon = if tool_name == "TodoWrite" { "📝" } else { "🔧" };
+                if let Some(input) = obj.get("input") {
+                    let input_str = self.format_tool_input_for_slack(input);
+                    return format!("{} {}: {}", tool_icon, tool_name, input_str);
+                } else {
+                    return format!("{} {}", tool_icon, tool_name);
+                }
+            }
+        }
+
+        message.content.clone()
+    }
+
+    /// Format tool input for Slack (simpler than terminal version)
+    fn format_tool_input_for_slack(&self, input: &Value) -> String {
+        match input {
+            Value::Object(obj) => {
+                if let Some(command) = obj.get("command") {
+                    if let Some(cmd_str) = command.as_str() {
+                        let truncated = cmd_str.chars().take(50).collect::<String>();
+                        return truncated + if cmd_str.len() > 50 { "..." } else { "" };
+                    }
+                }
+                "(...)".to_string()
+            }
+            Value::String(s) => {
+                let truncated = s.chars().take(50).collect::<String>();
+                truncated + if s.len() > 50 { "..." } else { "" }
+            }
+            _ => "(...)".to_string(),
         }
     }
 


### PR DESCRIPTION
## Summary
• Add detailed TodoWrite display instead of generic "(...)" message
• Implement separate formatting for terminal and Slack webhook outputs
• Use appropriate icons and formatting for each platform

## Changes

### Before
```
🔧 TodoWrite: (...)
```

### After - Terminal Display
**Simple mode:**
```
📝 TodoWrite: 3 tasks (1 pending, 1 in progress, 1 completed)
```

**Detailed mode:**
```
📝 TodoWrite:
  [ ] 🟢 Start task 3 
  [~] 🟡 Work on task 2 (in progress)
  [x] 🔴 Complete task 1 
```

### After - Slack Webhook (mrkdwn)
**Simple mode:**
```
📝 TodoWrite: 3 tasks (1 pending, 1 in progress, 1 completed)
```

**Detailed mode:**
```
📝 TodoWrite:
• ⭕ *Start task 3* (low priority)
• ⚠️ *Work on task 2* (in progress) (medium priority)
• ✅ *Complete task 1* (high priority)
```

## Implementation
• **Terminal display**: Checkbox format with priority color indicators
• **Slack webhook**: mrkdwn bullet points with status emojis and bold task names
• **Architecture**: Clean separation between terminal and webhook formatting logic
• **Testing**: Comprehensive unit tests for both display modes

🤖 Generated with [Claude Code](https://claude.ai/code)