### PR TITLE
Add automated release workflows with PR creation

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,42 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (patch/minor/major or specific version like 0.1.4)'
+        required: true
+        type: string
+        default: 'patch'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release-pr:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Install cargo-release
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-release
+    
+    - name: Create Release PR
+      uses: cargo-bins/release-pr@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Publish to crates.io
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    
+    - name: Publish to crates.io
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      run: cargo publish
+
+  # Create GitHub Release
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        draft: false
+        prerelease: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,29 @@ cargo install --path .
 cargo run -- watch --latest
 ```
 
+## Release Process
+
+### Standard Workflow
+
+1. **Create Release PR**
+   ```bash
+   gh workflow run "Create Release PR" --field version=patch
+   ```
+
+2. **Merge PR** → Review and merge the generated PR
+
+3. **Create Tag** → Tag push triggers automatic release
+   ```bash
+   git checkout main && git pull
+   git tag v0.1.4 && git push origin v0.1.4
+   ```
+
+### Prerequisites
+- Enable "Allow GitHub Actions to create and approve pull requests" in repository settings
+
+### Manual Alternative
+Manually edit Cargo.toml → create PR → merge → create tag
+
 ## Project Dependencies
 
 - **notify**: Cross-platform file watching (inotify on Linux)

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,30 @@
+# cargo-release configuration
+
+[package]
+# Don't publish to crates.io when using PR workflow
+# Publishing will be handled by the release.yml workflow after tag push
+publish = false
+
+# Don't push tags in PR workflow
+# Tag creation will be handled manually after PR merge
+tag = false
+
+# Don't push to git in PR workflow
+# PR creation will handle the push
+push = false
+
+# Enable changelog generation
+[package.metadata.release]
+# Tag format
+tag-name = "v{{version}}"
+
+# Disable confirmation prompts in CI
+no-dev-version = true
+pre-release-commit-message = "Release {{crate_name}} v{{version}}"
+pre-release-replacements = [
+  { file = "CHANGELOG.md", search = "## Unreleased", replace = "## Unreleased\n\n## [{{version}}] - {{date}}", exactly = 1 },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## Unreleased", exactly = 1 },
+]
+
+# Don't create dev version commits in PR workflow
+post-release-commit-message = false

--- a/release.toml
+++ b/release.toml
@@ -13,7 +13,7 @@ tag = false
 # PR creation will handle the push
 push = false
 
-# Enable changelog generation
+# Metadata for release
 [package.metadata.release]
 # Tag format
 tag-name = "v{{version}}"
@@ -21,10 +21,6 @@ tag-name = "v{{version}}"
 # Disable confirmation prompts in CI
 no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} v{{version}}"
-pre-release-replacements = [
-  { file = "CHANGELOG.md", search = "## Unreleased", replace = "## Unreleased\n\n## [{{version}}] - {{date}}", exactly = 1 },
-  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## Unreleased", exactly = 1 },
-]
 
 # Don't create dev version commits in PR workflow
 post-release-commit-message = false


### PR DESCRIPTION
## Summary
- Add workflow_dispatch triggered release-pr.yml for creating release PRs via cargo-release
- Add tag-triggered release.yml for automatic cargo publish + GitHub Release creation  
- Add release.toml configuration for cargo-release PR workflow
- Streamline CLAUDE.md release process documentation to 3 clear steps

## Test plan
- [ ] Test release-pr.yml workflow via GitHub Actions UI
- [ ] Verify PR creation with version updates
- [ ] Test full release flow: PR creation → merge → tag push → release

🤖 Generated with [Claude Code](https://claude.ai/code)