### PR TITLE
Fix release-pr workflow git fetch issue

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Remove `fetch-depth: 0` from checkout step to avoid `--unshallow` conflict with `cargo-bins/release-pr` action
- This fixes the workflow failure where `git fetch --unshallow` fails on a complete repository

## Test plan
- [ ] Verify the release-pr workflow can run successfully after this fix
- [ ] Test the patch version bump workflow dispatch

🤖 Generated with [Claude Code](https://claude.ai/code)