### PR TITLE
Fix cargo-release configuration format

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,6 +1,5 @@
 # cargo-release configuration
 
-[package]
 # Don't publish to crates.io when using PR workflow
 # Publishing will be handled by the release.yml workflow after tag push
 publish = false
@@ -13,14 +12,8 @@ tag = false
 # PR creation will handle the push
 push = false
 
-# Metadata for release
-[package.metadata.release]
 # Tag format
 tag-name = "v{{version}}"
 
-# Disable confirmation prompts in CI
-no-dev-version = true
+# Release commit message
 pre-release-commit-message = "Release {{crate_name}} v{{version}}"
-
-# Don't create dev version commits in PR workflow
-post-release-commit-message = false


### PR DESCRIPTION
## Summary
- Fix invalid `[package]` section in `release.toml` - this format is only valid in `Cargo.toml` under `[package.metadata.release]`
- Remove deprecated `no-dev-version` field that's not in the valid field list
- Remove malformed `post-release-commit-message = false` setting
- Move all configuration to top-level as required by `release.toml` format

## Background
The release-pr workflow was failing with:
```
unknown field `package`, expected one of `unstable`, `allow-branch`, `sign-commit`, `sign-tag`, `push-remote`, `registry`, `release`, `publish`, `verify`, `owners`, `push`, `push-options`, `shared-version`, `consolidate-commits`, `pre-release-commit-message`, `pre-release-replacements`, `pre-release-hook`, `tag-message`, `tag-prefix`, `tag-name`, `tag`, `enable-features`, `enable-all-features`, `dependent-version`, `metadata`, `target`, `rate-limit`, `certs-source`
```

## Test plan
- [ ] Verify the release-pr workflow runs successfully after this fix
- [ ] Test manual `cargo release --dry-run` command

🤖 Generated with [Claude Code](https://claude.ai/code)