### PR TITLE
Add session-specific monitoring capabilities

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -4,7 +4,6 @@ use notify::{event::CreateKind, Event, EventKind, RecursiveMode, Watcher};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::time::SystemTime;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio::time::{sleep, Duration};
 
@@ -89,39 +88,49 @@ impl LogWatcher {
         Ok(())
     }
 
-    /// Get the latest project
-    async fn get_latest_project(&self) -> Result<PathBuf> {
-        let entries =
-            fs::read_dir(&self.claude_dir).context("Claude projects directory not found")?;
+    /// Get the latest session file across all projects
+    async fn get_latest_session(&self) -> Result<PathBuf> {
+        let latest_session = fs::read_dir(&self.claude_dir)
+            .context("Claude projects directory not found")?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_type().map_or(false, |ft| ft.is_dir()))
+            .flat_map(|entry| {
+                fs::read_dir(entry.path())
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|f| f.ok())
+            })
+            .filter(|file| file.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
+            .filter_map(|file| {
+                file.metadata()
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .map(|modified| (file.path(), modified))
+            })
+            .max_by_key(|(_, modified)| *modified);
 
-        let mut latest_project: Option<(PathBuf, SystemTime)> = None;
-
-        for entry in entries {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                let project_path = entry.path();
-
-                // Find the most recently modified JSONL file in the project
-                if let Ok(files) = fs::read_dir(&project_path) {
-                    let latest_jsonl_time = files
-                        .filter_map(|f| f.ok())
-                        .filter(|f| f.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
-                        .filter_map(|f| f.metadata().ok().and_then(|m| m.modified().ok()))
-                        .max();
-
-                    if let Some(modified) = latest_jsonl_time {
-                        if latest_project.is_none() || modified > latest_project.as_ref().unwrap().1
-                        {
-                            latest_project = Some((project_path, modified));
-                        }
-                    }
-                }
-            }
-        }
-
-        latest_project
+        latest_session
             .map(|(path, _)| path)
-            .context("No projects found")
+            .context("No session files found")
+    }
+
+    /// Get the latest session file within a specific project
+    async fn get_latest_session_in_project(&self, project_path: &Path) -> Result<PathBuf> {
+        let latest_session = fs::read_dir(project_path)
+            .context("Project directory not found")?
+            .filter_map(|file| file.ok())
+            .filter(|file| file.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
+            .filter_map(|file| {
+                file.metadata()
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .map(|modified| (file.path(), modified))
+            })
+            .max_by_key(|(_, modified)| *modified);
+
+        latest_session
+            .map(|(path, _)| path)
+            .context("No session files found in project")
     }
 
     /// Monitor a specific project
@@ -156,10 +165,55 @@ impl LogWatcher {
         Ok(())
     }
 
-    /// Monitor the latest project
-    pub async fn watch_latest(&mut self) -> Result<()> {
-        let latest = self.get_latest_project().await?;
-        self.watch_project(&latest).await
+    /// Monitor a specific session file
+    pub async fn watch_session(&mut self, session_path: &Path) -> Result<()> {
+        let (tx, rx) = mpsc::channel();
+        let mut watcher = notify::recommended_watcher(tx)?;
+
+        // Watch the parent directory of the session file
+        let parent_dir = session_path.parent().context("Session file has no parent directory")?;
+        watcher.watch(parent_dir, RecursiveMode::NonRecursive)?;
+
+        // Check existing content if include_existing is enabled
+        if self.include_existing {
+            if let Err(e) = self.process_jsonl_file(session_path).await {
+                eprintln!("Error processing existing session file {:?}: {}", session_path, e);
+            }
+        }
+
+        println!("Started monitoring session file {session_path:?}. Press Ctrl+C to exit.");
+
+        loop {
+            match rx.recv() {
+                Ok(Ok(event)) => {
+                    // Only process events for our specific session file
+                    if event.paths.iter().any(|p| p == session_path) {
+                        if let Err(e) = self.handle_file_event(event).await {
+                            eprintln!("Error processing file event: {e}");
+                        }
+                    }
+                }
+                Ok(Err(e)) => eprintln!("File watching error: {e}"),
+                Err(e) => {
+                    eprintln!("Channel receive error: {e}");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Monitor the latest session across all projects
+    pub async fn watch_latest_session(&mut self) -> Result<()> {
+        let latest_session = self.get_latest_session().await?;
+        self.watch_session(&latest_session).await
+    }
+
+    /// Monitor the latest session within a specific project
+    pub async fn watch_latest_session_in_project(&mut self, project_path: &Path) -> Result<()> {
+        let latest_session = self.get_latest_session_in_project(project_path).await?;
+        self.watch_session(&latest_session).await
     }
 
     /// Monitor all projects


### PR DESCRIPTION
## Summary
• Add `--session-file` option to monitor specific session files
• Change `--latest` behavior to monitor latest session instead of latest project  
• Support `--latest` with `--project-path` to monitor latest session within a project
• Replace nested loops with iterator chains for better readability

🤖 Generated with [Claude Code](https://claude.ai/code)